### PR TITLE
GH-91 bumps versions and removes deprecated option for isort > 5

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,12 @@
 [tox]
-envlist = clean, py{36,37,38}, check, report
+envlist = clean, py{37,38,39}, check, report
 ;skip_missing_interpreters = true
 
 [testenv]
 deps =
     pytest
     pytest-travis-fold
-    ; https://youtrack.jetbrains.com/issue/PY-40980
-    coverage < 5
+    coverage
     pytest-cov
 commands =
     {posargs:pytest --cov=genloppy --cov-report=term-missing -vv tests}
@@ -22,13 +21,13 @@ deps =
     flake8
     readme-renderer
     pygments
-    isort
+    isort >= 5
 skip_install = true
 commands =
     python setup.py check --strict --metadata
     check-manifest {toxinidir}
     flake8 src tests setup.py
-    isort --verbose --check-only --diff --recursive src tests setup.py
+    isort --verbose --check-only --diff src tests setup.py
 
 [testenv:clean]
 commands = coverage erase
@@ -38,8 +37,7 @@ deps = coverage
 [testenv:codecov]
 deps =
     codecov>=1.4.0
-    ; https://youtrack.jetbrains.com/issue/PY-40980
-    coverage < 5
+    coverage
 passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
 skip_install = true
 commands =
@@ -47,8 +45,7 @@ commands =
     codecov -e TOXENV
 
 [testenv:report]
-; https://youtrack.jetbrains.com/issue/PY-40980
-deps = coverage < 5
+deps = coverage
 skip_install = true
 commands =
     coverage report


### PR DESCRIPTION
* closes GH-91